### PR TITLE
fix: upgrading meilisearch version compatibility to 1.34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM getmeili/meilisearch:v1.29
+FROM getmeili/meilisearch:v1.34
 
 RUN apk add --no-cache python3 py-pip
 


### PR DESCRIPTION
Upgrading tests to test against https://hub.docker.com/layers/getmeili/meilisearch/v1.34/images/sha256-779b7f3ec3279f9230b5e6399814ee93a873b077433a5ef635d644db3d491a05