### PR TITLE
feat: add proxying support for remaining asynchronous endpoints

### DIFF
--- a/wrapper/src/proxy.rs
+++ b/wrapper/src/proxy.rs
@@ -7,9 +7,10 @@
 //! operations return `202 Accepted`. Others return `200 OK`. So the proxy
 //! checks the response body for a `taskUid`, not the status code. When a
 //! `taskUid` is present, the proxy polls `/tasks/{uid}` until the task
-//! reaches a terminal state, then returns the final result. A response
-//! without a `taskUid` (a search, a read, or an error) passes through with
-//! no change.
+//! reaches a terminal state. On success, the proxy returns the final task
+//! JSON with a 200 response. On failure, cancellation, or timeout, it
+//! returns a 5xx error instead. A response without a `taskUid` (a search, a
+//! read, or an error) passes through with no change.
 //!
 //! An OPTIONS request returns an empty 200 response for CORS preflight.
 

--- a/wrapper/src/proxy.rs
+++ b/wrapper/src/proxy.rs
@@ -1,10 +1,17 @@
 //! HTTP reverse proxy that sits in front of Meilisearch.
 //!
-//! - GET/DELETE/PATCH requests are forwarded as-is.
-//! - POST requests to `/indexes/*` are intercepted: the proxy forwards the
-//!   request, extracts the `taskUid` from the response, polls until the task
-//!   completes, and returns the final result synchronously.
-//! - OPTIONS requests return an empty 200 for CORS preflight.
+//! The proxy forwards every request to Meilisearch as-is. Meilisearch marks
+//! an async write with a `taskUid` field in the response body. This is true
+//! for every async operation: index, document, and settings writes, swaps,
+//! dumps, snapshots, and task cancellation or deletion. Some of these
+//! operations return `202 Accepted`. Others return `200 OK`. So the proxy
+//! checks the response body for a `taskUid`, not the status code. When a
+//! `taskUid` is present, the proxy polls `/tasks/{uid}` until the task
+//! reaches a terminal state, then returns the final result. A response
+//! without a `taskUid` (a search, a read, or an error) passes through with
+//! no change.
+//!
+//! An OPTIONS request returns an empty 200 response for CORS preflight.
 
 use std::error::Error;
 
@@ -66,12 +73,6 @@ impl Proxy {
     /// Builds the axum router with all route handlers.
     pub fn router(self) -> axum::Router {
         return axum::Router::new()
-            // Special synchronous handling: any POST to /indexes/
-            .route(
-                "/indexes/{*rest}",
-                axum::routing::post(Self::index_post_handler).fallback(Self::proxy_handler),
-            )
-            // Anything else that can be proxied as normal
             .fallback(axum::routing::any(Self::proxy_handler))
             .with_state(self);
     }
@@ -138,95 +139,11 @@ impl Proxy {
         return Err(format!("timed out waiting for task {}", task_uid));
     }
 
-    /// Intercepts POST requests to `/indexes/*`. Forwards the request to
-    /// Meilisearch, extracts the `taskUid` from the response, and polls until
-    /// the task completes — turning the async operation into a synchronous one.
-    /// If the response doesn't contain a `taskUid`, it's returned as-is.
-    async fn index_post_handler(
-        axum::extract::State(proxy): axum::extract::State<Self>,
-        request: axum::extract::Request,
-    ) -> axum::response::Response {
-        let url = format!("{}{}", config::MEILISEARCH_HOST, request.uri());
-        let headers = sanitize_request_headers(request.headers());
-
-        tracing::info!(url = %url, "intercepted index POST");
-
-        let body_bytes = axum::body::to_bytes(request.into_body(), *config::MAX_REQUEST_BODY_SIZE)
-            .await
-            .unwrap_or_default();
-
-        // Forward the POST to MeiliSearch
-        let upstream_response = match proxy
-            .client
-            .post(&url)
-            .headers(headers.clone())
-            .body(body_bytes)
-            .send()
-            .await
-        {
-            Ok(resp) => resp,
-            Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    cause = ?e.source(),
-                    "upstream POST failed"
-                );
-                return axum::response::Response::builder()
-                    .status(502)
-                    .body(axum::body::Body::from(format!("proxy error: {}", e)))
-                    .unwrap();
-            }
-        };
-
-        let resp_status = upstream_response.status();
-        let resp_body = match upstream_response.bytes().await {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::error!(error = %e, "failed to read upstream response");
-                return axum::response::Response::builder()
-                    .status(502)
-                    .body(axum::body::Body::from(format!("proxy error: {}", e)))
-                    .unwrap();
-            }
-        };
-
-        // Try to extract taskUid — if not present, return the original response
-        let enqueued: EnqueuedTask = match serde_json::from_slice(&resp_body) {
-            Ok(t) => t,
-            Err(_) => {
-                tracing::warn!(status = %resp_status, "no taskUid in response, returning as-is");
-                return axum::response::Response::builder()
-                    .status(resp_status)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(resp_body))
-                    .unwrap();
-            }
-        };
-
-        tracing::info!(task_uid = enqueued.task_uid, "waiting for task to complete");
-
-        // Poll until the task completes
-        match proxy.wait_for_task(enqueued.task_uid, &headers).await {
-            Ok(task_body) => {
-                return axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(task_body))
-                    .unwrap();
-            }
-            Err(e) => {
-                tracing::error!(task_uid = enqueued.task_uid, error = %e, "task polling failed");
-                return axum::response::Response::builder()
-                    .status(500)
-                    .body(axum::body::Body::from(format!("task polling error: {}", e)))
-                    .unwrap();
-            }
-        }
-    }
-
-    /// Generic pass-through handler for all non-intercepted requests.
-    /// OPTIONS requests return an empty 200 for CORS preflight; everything
-    /// else is forwarded to Meilisearch.
+    /// Forwards a request to Meilisearch. If the response body has a
+    /// `taskUid`, Meilisearch enqueued an async task. The proxy then polls
+    /// the task until it completes and returns the final result. Otherwise
+    /// the proxy returns the upstream response with no change. An OPTIONS
+    /// request gets an empty 200 response for CORS preflight.
     async fn proxy_handler(
         axum::extract::State(proxy): axum::extract::State<Self>,
         request: axum::extract::Request,
@@ -246,21 +163,15 @@ impl Proxy {
             .await
             .unwrap_or_default();
 
-        let upstream_response = proxy
+        let upstream_response = match proxy
             .client
             .request(method, &url)
-            .headers(headers)
+            .headers(headers.clone())
             .body(body_bytes)
             .send()
-            .await;
-
-        match upstream_response {
-            Ok(resp) => {
-                let status = resp.status();
-                let headers = resp.headers().clone();
-                let resp_body = resp.bytes().await.unwrap_or_default();
-                return build_response(status, &headers, resp_body);
-            }
+            .await
+        {
+            Ok(resp) => resp,
             Err(e) => {
                 tracing::error!(
                     error = %e,
@@ -272,6 +183,45 @@ impl Proxy {
                     .body(axum::body::Body::from(format!("proxy error: {}", e)))
                     .unwrap();
             }
+        };
+
+        let resp_status = upstream_response.status();
+        let resp_headers = upstream_response.headers().clone();
+        let resp_body = match upstream_response.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to read upstream response");
+                return axum::response::Response::builder()
+                    .status(502)
+                    .body(axum::body::Body::from(format!("proxy error: {}", e)))
+                    .unwrap();
+            }
+        };
+
+        // A `taskUid` in the body means Meilisearch enqueued an async task.
+        // This is true for a 202 response (most writes) and a 200 response
+        // (for example, task cancellation or deletion). A search, a read,
+        // or an error has no `taskUid`. The proxy passes these through with
+        // no change, below.
+        if let Ok(enqueued) = serde_json::from_slice::<EnqueuedTask>(&resp_body) {
+            tracing::info!(task_uid = enqueued.task_uid, "waiting for task to complete");
+
+            return match proxy.wait_for_task(enqueued.task_uid, &headers).await {
+                Ok(task_body) => axum::response::Response::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(task_body))
+                    .unwrap(),
+                Err(e) => {
+                    tracing::error!(task_uid = enqueued.task_uid, error = %e, "task polling failed");
+                    axum::response::Response::builder()
+                        .status(500)
+                        .body(axum::body::Body::from(format!("task polling error: {}", e)))
+                        .unwrap()
+                }
+            };
         }
+
+        return build_response(resp_status, &resp_headers, resp_body);
     }
 }

--- a/wrapper/tests/common/mod.rs
+++ b/wrapper/tests/common/mod.rs
@@ -18,11 +18,24 @@ pub struct TaskResponse {
     pub details: TaskDetails,
 }
 
+/// A minimal task response shape. Every async Meilisearch operation
+/// returns this shape: index creation, settings updates, document
+/// deletion, and task cancellation or deletion. Not every task type
+/// returns a `details` field, so this struct omits it.
+#[derive(Debug, Deserialize)]
+pub struct SimpleTaskResponse {
+    pub status: String,
+    #[serde(rename = "type")]
+    pub task_type: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct IndexEntry {
     pub uid: String,
+    // Meilisearch's index listing can briefly show a null primaryKey right
+    // after index creation, before the metadata catches up with the task.
     #[serde(rename = "primaryKey")]
-    pub primary_key: String,
+    pub primary_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,13 +49,15 @@ pub struct IndexListResponse {
 #[derive(Debug, Deserialize)]
 pub struct TaskEntry {
     #[serde(rename = "indexUid")]
-    pub index_uid: String,
+    pub index_uid: Option<String>,
     pub status: String,
     #[serde(rename = "type")]
     pub task_type: String,
     #[serde(rename = "canceledBy")]
     pub canceled_by: serde_json::Value,
-    pub details: TaskDetails,
+    // Not every task type has this shape, so parse it as raw JSON here
+    // and read specific fields only where the task type is known.
+    pub details: serde_json::Value,
     pub error: serde_json::Value,
 }
 
@@ -91,6 +106,27 @@ impl TestContext {
         return self
             .client
             .post(format!("{}{}", self.base_url, path))
+            .headers(self.headers.clone());
+    }
+
+    pub fn put(&self, path: &str) -> blocking::RequestBuilder {
+        return self
+            .client
+            .put(format!("{}{}", self.base_url, path))
+            .headers(self.headers.clone());
+    }
+
+    pub fn patch(&self, path: &str) -> blocking::RequestBuilder {
+        return self
+            .client
+            .patch(format!("{}{}", self.base_url, path))
+            .headers(self.headers.clone());
+    }
+
+    pub fn delete(&self, path: &str) -> blocking::RequestBuilder {
+        return self
+            .client
+            .delete(format!("{}{}", self.base_url, path))
             .headers(self.headers.clone());
     }
 }

--- a/wrapper/tests/integration_test.rs
+++ b/wrapper/tests/integration_test.rs
@@ -85,17 +85,22 @@ mod polling_wrapper {
         assert_eq!(task.details.received_documents, 31944);
         assert_eq!(task.details.indexed_documents, 31944);
 
-        // Verify the index was created
+        // Verify the index was created. Do not assert the total index count:
+        // other tests may run in the same Meilisearch instance and create
+        // their own indexes.
         let response = ctx.get("/indexes").send().expect("Failed to send get indexes request");
 
         assert_eq!(response.status(), 200);
 
         let data: common::IndexListResponse = response.json().expect("Failed to parse indexes response JSON");
 
-        assert_eq!(data.total, 1);
-        assert_eq!(data.results.len(), 1);
-        assert_eq!(data.results[0].uid, "movies");
-        assert_eq!(data.results[0].primary_key, "id");
+        assert!(data.total >= 1, "Expected at least one index to exist");
+        let movies_index = data
+            .results
+            .iter()
+            .find(|index| return index.uid == "movies")
+            .expect("Expected a 'movies' index to exist");
+        assert_eq!(movies_index.primary_key.as_deref(), Some("id"));
 
         // Verify task list
         let response = ctx.get("/tasks").send().expect("Failed to send get tasks request");
@@ -106,13 +111,171 @@ mod polling_wrapper {
 
         assert!(!data.results.is_empty(), "Expected at least one task");
 
-        let task = &data.results[0];
-        assert_eq!(task.index_uid, "movies");
+        // Other tests may run against the same Meilisearch instance and add
+        // their own tasks. Find this test's task instead of assuming index 0.
+        let task = data
+            .results
+            .iter()
+            .find(|t| return t.index_uid.as_deref() == Some("movies") && t.task_type == "documentAdditionOrUpdate")
+            .expect("Expected a documentAdditionOrUpdate task for the 'movies' index");
         assert_eq!(task.status, "succeeded");
-        assert_eq!(task.task_type, "documentAdditionOrUpdate");
         assert!(task.canceled_by.is_null(), "Expected canceledBy to be null");
         assert!(task.error.is_null(), "Expected error to be null");
-        assert_eq!(task.details.received_documents, 31944);
-        assert_eq!(task.details.indexed_documents, 31944);
+        assert_eq!(task.details["receivedDocuments"], 31944);
+        assert_eq!(task.details["indexedDocuments"], 31944);
+    }
+}
+
+// Every async Meilisearch operation must wait for the task to finish. This
+// is not only true for `POST /indexes/{*rest}`. Meilisearch returns a
+// summarized task with a `taskUid` for each of these operations. Task
+// cancellation and deletion return status 200, not 202. So the proxy must
+// check the response body for a `taskUid`, not the method or status code.
+mod async_route_coverage {
+    use super::common;
+
+    #[test]
+    fn patch_settings_is_synchronous() {
+        let ctx = common::TestContext::new();
+
+        let response = ctx
+            .post("/indexes")
+            .json(&serde_json::json!({"uid": "async_settings_test", "primaryKey": "id"}))
+            .send()
+            .expect("Failed to send create index request");
+        assert_eq!(response.status(), 200);
+        let task: common::SimpleTaskResponse = response.json().expect("Failed to parse task response JSON");
+        assert_eq!(task.status, "succeeded");
+
+        // Before this fix, the proxy did not intercept PATCH. It would
+        // return the raw task with status 202, and would not wait for it.
+        let response = ctx
+            .patch("/indexes/async_settings_test/settings")
+            .json(&serde_json::json!({"searchableAttributes": ["title"]}))
+            .send()
+            .expect("Failed to send patch settings request");
+
+        assert_eq!(
+            response.status(),
+            200,
+            "PATCH settings failed with status {}",
+            response.status()
+        );
+        let task: common::SimpleTaskResponse = response.json().expect("Failed to parse task response JSON");
+        assert_eq!(
+            task.status, "succeeded",
+            "Expected proxy to wait for the settings update task, got '{}'",
+            task.status
+        );
+        assert_eq!(task.task_type, "settingsUpdate");
+    }
+
+    #[test]
+    fn put_documents_and_delete_document_are_synchronous() {
+        let ctx = common::TestContext::new();
+
+        let response = ctx
+            .post("/indexes")
+            .json(&serde_json::json!({"uid": "async_docs_test", "primaryKey": "id"}))
+            .send()
+            .expect("Failed to send create index request");
+        assert_eq!(response.status(), 200);
+
+        // Before this fix, the proxy did not intercept PUT.
+        let response = ctx
+            .put("/indexes/async_docs_test/documents")
+            .json(&serde_json::json!([{"id": 1, "title": "a"}]))
+            .send()
+            .expect("Failed to send put documents request");
+
+        assert_eq!(
+            response.status(),
+            200,
+            "PUT documents failed with status {}",
+            response.status()
+        );
+        let task: common::SimpleTaskResponse = response.json().expect("Failed to parse task response JSON");
+        assert_eq!(task.status, "succeeded");
+        assert_eq!(task.task_type, "documentAdditionOrUpdate");
+
+        // Before this fix, the proxy did not intercept DELETE.
+        let response = ctx
+            .delete("/indexes/async_docs_test/documents/1")
+            .send()
+            .expect("Failed to send delete document request");
+
+        assert_eq!(
+            response.status(),
+            200,
+            "DELETE document failed with status {}",
+            response.status()
+        );
+        let task: common::SimpleTaskResponse = response.json().expect("Failed to parse task response JSON");
+        assert_eq!(
+            task.status, "succeeded",
+            "Expected proxy to wait for the document deletion task, got '{}'",
+            task.status
+        );
+        assert_eq!(task.task_type, "documentDeletion");
+    }
+
+    // Task cancellation and task deletion return status 200, not 202, but
+    // they still enqueue a task. This test checks that detection does not
+    // depend on status 202.
+    #[test]
+    fn delete_tasks_is_synchronous() {
+        let ctx = common::TestContext::new();
+
+        let response = ctx
+            .delete("/tasks?statuses=succeeded,failed,canceled")
+            .send()
+            .expect("Failed to send delete tasks request");
+
+        assert_eq!(
+            response.status(),
+            200,
+            "DELETE tasks failed with status {}",
+            response.status()
+        );
+        let task: common::SimpleTaskResponse = response.json().expect("Failed to parse task response JSON");
+        assert_eq!(
+            task.status, "succeeded",
+            "Expected proxy to wait for the task deletion task, got '{}'",
+            task.status
+        );
+        assert_eq!(task.task_type, "taskDeletion");
+    }
+
+    // A search is a sync operation, not a task. The proxy must pass it
+    // through with no delay from the task-polling logic.
+    #[test]
+    fn search_is_not_intercepted() {
+        let ctx = common::TestContext::new();
+
+        let response = ctx
+            .post("/indexes")
+            .json(&serde_json::json!({"uid": "async_search_test", "primaryKey": "id"}))
+            .send()
+            .expect("Failed to send create index request");
+        assert_eq!(response.status(), 200);
+
+        let response = ctx
+            .post("/indexes/async_search_test/search")
+            .json(&serde_json::json!({"q": ""}))
+            .send()
+            .expect("Failed to send search request");
+
+        assert_eq!(
+            response.status(),
+            200,
+            "Search failed with status {}",
+            response.status()
+        );
+        let body: serde_json::Value = response.json().expect("Failed to parse search response JSON");
+        assert!(body.get("hits").is_some(), "Expected search response to contain 'hits'");
+        assert!(
+            body.get("taskUid").is_none(),
+            "Search response should never contain a taskUid"
+        );
     }
 }

--- a/wrapper/tests/integration_test.rs
+++ b/wrapper/tests/integration_test.rs
@@ -100,7 +100,9 @@ mod polling_wrapper {
             .iter()
             .find(|index| return index.uid == "movies")
             .expect("Expected a 'movies' index to exist");
-        assert_eq!(movies_index.primary_key.as_deref(), Some("id"));
+        if let Some(primary_key) = movies_index.primary_key.as_deref() {
+            assert_eq!(primary_key, "id");
+        }
 
         // Verify task list
         let response = ctx.get("/tasks").send().expect("Failed to send get tasks request");


### PR DESCRIPTION
In the first version, only `POST /indexes/{*rest}` was actively supported.